### PR TITLE
Fix test seven and nine

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Test method `test_custom_error_message()`.
 
 ## Task 9. Your Own Validation Rule.
 
-In `app/Http/Controllers/ArticleController.php` file, in `store` method, the code uses `Uppercase` validation rule that you need to create with Artisan command, and fill in with the rule of "title" having first letter as uppercase.
+In `app/Http/Controllers/ArticleController.php` file, in `store` method, the code uses `Uppercase` validation rule that you need to create with Artisan command, and fill in with the rule of "title" having first letter as uppercase with the error message "The title does not start with an uppercased letter".
 
 Test method `test_custom_validation_rule()`.
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,5 +41,6 @@ class User extends Authenticatable
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'is_admin' => 'boolean',
     ];
 }

--- a/tests/Feature/ValidationTest.php
+++ b/tests/Feature/ValidationTest.php
@@ -94,7 +94,7 @@ class ValidationTest extends TestCase
 
         $user = User::where('name', $updatedUser['name'])->first();
         $this->assertNotNull($user);
-        $this->assertEquals(false, $user->is_admin);
+        $this->assertFalse($user->is_admin);
     }
 
     public function test_custom_error_message()
@@ -107,6 +107,8 @@ class ValidationTest extends TestCase
     public function test_custom_validation_rule()
     {
         $response = $this->post('articles', ['title' => 'lowercase']);
-        $response->assertSessionHasErrors('title')->assertStatus(302);
+        $response->assertSessionHasErrors([
+            'title' => 'The title does not start with an uppercased letter.',
+        ])->assertStatus(302);
     }
 }

--- a/tests/Feature/ValidationTest.php
+++ b/tests/Feature/ValidationTest.php
@@ -108,7 +108,10 @@ class ValidationTest extends TestCase
     {
         $response = $this->post('articles', ['title' => 'lowercase']);
         $response->assertSessionHasErrors([
-            'title' => 'The title does not start with an uppercased letter.',
+            'title' => 'The title does not start with an uppercased letter',
         ])->assertStatus(302);
+
+        $response = $this->post('articles', ['title' => 'Uppercase']);
+        $response->assertStatus(200);
     }
 }


### PR DESCRIPTION
This PR fixes issues with tests `test_update_forbidden_field` and `test_custom_validation_rule`.

The first issue relates to testing the equality of `is_admin` being equal to `false`, since `is_admin` is an integer. PHPUnit cannot assert `0` matches `false`. We fix this by casting `is_admin` to a boolean and simplifying the equality check to use `assertFalse` instead.

<details>
<summary>Screenshots of issue and fix.</summary>

##### `$request->validated()` with current test.

![CLI failing test](https://user-images.githubusercontent.com/2221746/144251230-3750febc-c088-4b23-8083-bbbc58744a09.png)

##### `$request->validated()` with fixed test.

![CLI passing test](https://user-images.githubusercontent.com/2221746/144251309-e2997bfe-2c03-44bc-8f04-1811baa038d3.png)

</details>

----

The latter issue has to do with checking that the custom rule follows the criteria. The test case doesn't check if the custom rule has been implemented correctly. Meaning the test passes by just creating the `Uppercase` rule and leaving it as the generated stub or returning false from `passes` to trigger an error message.

This PR fixes that bypass by first checking for the rules custom message, which has been added to the README. It also checks that the valdation rule is correct by also testing for a successful post that will pass the custom validation rule.

<details>
<summary>Screenshots of issue and fix.</summary>

##### Rule returning false passes current test.

![CLI passing test](https://user-images.githubusercontent.com/2221746/144253195-5b6447ca-3f13-4d80-b936-dfa7934a3198.png)

##### Rule returning false fails with fix.

![CLI failing test](https://user-images.githubusercontent.com/2221746/144253541-4cac1534-1b43-4444-867e-c7de7cf4ee1c.png)

</details>