### PR TITLE
Fix: readme instructions for task 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Test method `test_old_value_stays_in_form_after_validation_error()`.
 
 ## Task 6. Form Request Validation.
 
-In `app/Http/Controllers/ItemController.php` file, validation is performed via class StoreItemRequest, but that class doesn't exist, intentionally. Your task is to create it, with parameters of authorized true, and validation rules of name/title as required fields.
+In `app/Http/Controllers/ItemController.php` file, validation is performed via class StoreItemRequest, but that class doesn't exist, intentionally. Your task is to create it, with parameters of authorized true, and validation rules of name/description as required fields.
 
 Test method `test_form_request_validation()`.
 


### PR DESCRIPTION
In the README description, task number 6 is described to `"...validation rules of name/title as required fields."` when test checks for name and **description** fields.

This PR fix this description!